### PR TITLE
Add entities interfaces for internal use

### DIFF
--- a/server/src/entities/answer.ts
+++ b/server/src/entities/answer.ts
@@ -1,6 +1,7 @@
-import { IQuestion } from "./Question";
+import { IQuestion } from "./question";
 
 export interface IAnswer {
+  id: string;
   question: IQuestion;
   value: string;
 }

--- a/server/src/entities/answer.ts
+++ b/server/src/entities/answer.ts
@@ -1,0 +1,6 @@
+import { IQuestion } from "./Question";
+
+export interface IAnswer {
+  question: IQuestion;
+  value: string;
+}

--- a/server/src/entities/form.ts
+++ b/server/src/entities/form.ts
@@ -1,0 +1,11 @@
+import { IInterviewSlot } from "./InterviewSlot";
+import { IQuestion } from "./Question";
+import { IResponse } from "./Response";
+import { IUser } from "./User";
+
+export interface IForm {
+  owners: [IUser];
+  questions: [IQuestion];
+  responses: [IResponse];
+  interviewSlots: [IInterviewSlot];
+}

--- a/server/src/entities/form.ts
+++ b/server/src/entities/form.ts
@@ -1,9 +1,10 @@
-import { IInterviewSlot } from "./InterviewSlot";
-import { IQuestion } from "./Question";
-import { IResponse } from "./Response";
-import { IUser } from "./User";
+import { IInterviewSlot } from "./interviewSlot";
+import { IQuestion } from "./question";
+import { IResponse } from "./response";
+import { IUser } from "./user";
 
 export interface IForm {
+  id: string;
   owners: [IUser];
   questions: [IQuestion];
   responses: [IResponse];

--- a/server/src/entities/index.ts
+++ b/server/src/entities/index.ts
@@ -1,0 +1,6 @@
+export { IAnswer } from "./answer";
+export { IForm } from "./form";
+export { IInterviewSlot } from "./interviewSlot";
+export { IQuestion } from "./question";
+export { IResponse } from "./response";
+export { IUser } from "./user";

--- a/server/src/entities/interviewSlot.ts
+++ b/server/src/entities/interviewSlot.ts
@@ -1,0 +1,6 @@
+export interface IInterviewSlot {
+  start: Date;
+  end: Date;
+  available: boolean;
+  intervieweeEmail: string;
+}

--- a/server/src/entities/interviewSlot.ts
+++ b/server/src/entities/interviewSlot.ts
@@ -1,4 +1,5 @@
 export interface IInterviewSlot {
+  id: string;
   start: Date;
   end: Date;
   available: boolean;

--- a/server/src/entities/question.ts
+++ b/server/src/entities/question.ts
@@ -1,4 +1,5 @@
 export interface IQuestion {
+  id: string;
   prompt: string;
   options: [string];
   type: string;

--- a/server/src/entities/question.ts
+++ b/server/src/entities/question.ts
@@ -1,0 +1,5 @@
+export interface IQuestion {
+  prompt: string;
+  options: [string];
+  type: string;
+}

--- a/server/src/entities/response.ts
+++ b/server/src/entities/response.ts
@@ -1,0 +1,14 @@
+import { IAnswer } from "./Answer";
+import { IUser } from "./User";
+
+interface IScore {
+  score: number;
+  notes: string;
+  user: IUser;
+}
+
+export interface IResponse {
+  respondent: string;
+  answers: [IAnswer];
+  scores: [IScore];
+}

--- a/server/src/entities/response.ts
+++ b/server/src/entities/response.ts
@@ -1,5 +1,5 @@
-import { IAnswer } from "./Answer";
-import { IUser } from "./User";
+import { IAnswer } from "./answer";
+import { IUser } from "./user";
 
 interface IScore {
   score: number;
@@ -8,6 +8,7 @@ interface IScore {
 }
 
 export interface IResponse {
+  id: string;
   respondent: string;
   answers: [IAnswer];
   scores: [IScore];

--- a/server/src/entities/user.ts
+++ b/server/src/entities/user.ts
@@ -1,0 +1,6 @@
+export interface IUser {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+}

--- a/server/src/services/form.ts
+++ b/server/src/services/form.ts
@@ -1,5 +1,9 @@
+import { IForm, IResponse, IUser } from "../entities";
+
 export interface IFormService {
-  createNewForm();
-  saveForm(formID: string, questions);
-  addResponse(formID: string, response);
+  createNewForm(author: IUser): Promise<IForm>;
+  getFormByID(id: string): Promise<IForm>;
+  saveForm(form: IForm): Promise<void>;
+  addResponse(formID: string, response: IResponse): Promise<void>;
+  addOwner(formID: string, newOwner: IUser): Promise<void>;
 }

--- a/server/src/services/form.ts
+++ b/server/src/services/form.ts
@@ -1,0 +1,5 @@
+export interface IFormService {
+  createNewForm();
+  saveForm(formID: string, questions);
+  addResponse(formID: string, response);
+}

--- a/server/src/services/user.ts
+++ b/server/src/services/user.ts
@@ -1,18 +1,29 @@
+import { IUser } from "../entities";
+
 export interface IUserService {
-  findUserByUsernameAndPassword(username: string, password: string);
-  findUserById(id: string);
-  newUser(username: string, password: string);
+  findUserByUsernameAndPassword(
+    username: string,
+    password: string
+  ): Promise<IUser>;
+  findUserById(id: string): Promise<IUser>;
+  newUser(username: string, password: string): Promise<IUser>;
 }
 
 class DatabaseUserService implements IUserService {
-  public findUserByUsernameAndPassword(username: string, password: string) {
+  public async findUserByUsernameAndPassword(
+    username: string,
+    password: string
+  ): Promise<IUser> {
     // TODO
+    return null;
   }
-  public findUserById(id: string) {
+  public async findUserById(id: string): Promise<IUser> {
     // TODO
+    return null;
   }
-  public newUser(username: string, password: string) {
+  public async newUser(username: string, password: string): Promise<IUser> {
     // TODO
+    return null;
   }
 }
 


### PR DESCRIPTION
These should match the form of the database objects so that database objects are easy to use while promoting loose coupling so that the rest of the server does not need to know about the database internals.